### PR TITLE
proposed fix to EventDispatcher

### DIFF
--- a/src/egret-shim.js
+++ b/src/egret-shim.js
@@ -27,7 +27,7 @@ if (!window.egret) {
                 thisObject: thisObject,
                 useCapture: useCapture,
                 priority: priority,
-                once: dispatchOnce
+                dispatchOnce: dispatchOnce
             });
         },
         once: function(type, listener, thisObject, useCapture, priority) {


### PR DESCRIPTION
At line 60 you call -> if (listenerObj.dispatchOnce) but the data member is called once. Because once if a named function, I propose to call the data member dispatchOnce, same pattern as other data members.